### PR TITLE
INCS variable does not exist

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -40,7 +40,7 @@ endif
 LVER=5.3
 PREFIX=$(shell pkg-config --variable=prefix lua)
 INCDIR=$(shell pkg-config --variable=includedir lua)
-#LDFLAGS=$(shell pkg-config --libs lua) -lcrypt
+LDFLAGS=$(shell pkg-config --libs lua) -lcrypt
 LDFLAGS:=$(LDFLAGS) -lcrypt
 # clang can be substituted with gcc (command line args compatible)
 CC=clang
@@ -81,7 +81,7 @@ test: $(SRCDIR)
 	$(LD) -O -shared $< -o $@ $(LDFLAGS) $(LIBS)
 
 %.o: %.c
-	$(CC) -I$(INCS) $(CFLAGS) -c $< -o $@
+	$(CC) -I$(INCDIR) $(CFLAGS) -c $< -o $@
 
 echo:
 	@echo "PLAT= $(PLAT)"

--- a/src/Makefile
+++ b/src/Makefile
@@ -40,8 +40,8 @@ endif
 LVER=5.3
 PREFIX=$(shell pkg-config --variable=prefix lua)
 INCDIR=$(shell pkg-config --variable=includedir lua)
-LDFLAGS=$(shell pkg-config --libs lua) -lcrypt
-#LDFLAGS:=$(LDFLAGS) -lcrypt
+#LDFLAGS=$(shell pkg-config --libs lua) -lcrypt
+LDFLAGS:=$(LDFLAGS) -lcrypt
 # clang can be substituted with gcc (command line args compatible)
 CC=clang
 LD=clang

--- a/src/Makefile
+++ b/src/Makefile
@@ -41,7 +41,7 @@ LVER=5.3
 PREFIX=$(shell pkg-config --variable=prefix lua)
 INCDIR=$(shell pkg-config --variable=includedir lua)
 LDFLAGS=$(shell pkg-config --libs lua) -lcrypt
-LDFLAGS:=$(LDFLAGS) -lcrypt
+#LDFLAGS:=$(LDFLAGS) -lcrypt
 # clang can be substituted with gcc (command line args compatible)
 CC=clang
 LD=clang


### PR DESCRIPTION
Yours may be building despite your include flag. Lua-t and other libraries seem to compile on my Arch machine because pacman installs the lua headers in /usr/include. The result is everything builds even after commenting out the -I flag altogether. 
